### PR TITLE
Fix error with passing contribution rules

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -379,9 +379,7 @@ def get_deterministic_contribution_vector(contribution_rule, N, **kwargs):
     Parameters
     ------------
 
-    contribution_rule: a function that takes an index, and returns the
-
-    contribution of that player.
+    contribution_rule: a function that takes a player's index and Ns, and returns the contribution of that player.
 
     N: int, the number of players
 
@@ -390,7 +388,7 @@ def get_deterministic_contribution_vector(contribution_rule, N, **kwargs):
 
     numpy.array: a vector of contributions by player"""
 
-    return np.array([contribution_rule(index=x, **kwargs) for x in range(N)])
+    return np.array([contribution_rule(index=x, N=N, **kwargs) for x in range(N)])
 
 
 def get_dirichlet_contribution_vector(N, alpha_rule, M, **kwargs):

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1154,7 +1154,7 @@ def test_get_deterministic_contribution_vector_for_homogeneous_case():
     """Tests the get_deterministic_contribution_vector function for a homogeneous
     case"""
 
-    def homogeneous_contribution_rule(index):
+    def homogeneous_contribution_rule(index, N):
         """The contribution of player i (indexed from 1) is always equal to 2
 
         This is a test that shows the ability of get_deterministic_contribution_vector to
@@ -1178,7 +1178,7 @@ def test_get_deterministic_contribution_vector_for_heterogeneous_case():
     """Tests the get_deterministic_contribution_vector function for a homogeneous
     case"""
 
-    def heterogeneous_contribution_rule(index):
+    def heterogeneous_contribution_rule(index, N):
         """The contribution of player i (indexed from 1) is given by:
 
         2 * i.
@@ -1207,7 +1207,7 @@ def test_get_deterministic_contribution_vector_for_kwargs_case():
     """Tests the get_deterministic_contribution_vector function for a homogeneous
     case"""
 
-    def homogeneous_contribution_rule(index, discount):
+    def homogeneous_contribution_rule(index, N, discount):
         """The contribution of player i (indexed from 1), with a discount
         value <2, is given by:
 


### PR DESCRIPTION
It was breaking when we tried to pass N into a contribution rule in get_deterministic_contribution_vector. I've now fixed this, though it now needs to be specified that all contribution rules must take N as an argument. The other way to do this is (from what I've read online) to do with signature inspection. Eventually there'll be a better fix for this, but for now this fix works.