### PR TITLE
Add monte carlo simulation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -685,3 +685,92 @@ def calculate_steady_state(transition_matrix):
         raise ValueError("No eigenvector found")
 
     return np.array(sym.simplify(one_eigenvector / sum(one_eigenvector)).T)[0]
+
+
+def simulate_markov_chain(
+    transition_matrix, starting_state_index=None, time_steps=1000
+):
+    """
+    Performs a single simulation of a Markov chain. Given a transition_matrix
+    and a starting state, this will simulate a certain number of time steps in
+    the Markov chain, and return the number of time steps spent in each state.
+
+    Parameters
+    -----------
+    transition_matrix - numpy.array: a transition matrix for the Markov chain
+    in question.
+
+    time_steps - int: how many turns to play the public goods game for. By
+    default, this is set to 1000.
+
+    starting_state_index - int: the index of the state to begin in. If None,
+    this will start in a randomly chosen state, and is set to None by default.
+
+    returns:
+    --------
+    numpy.array - the number of time steps spent in each state."""
+
+    number_of_states = transition_matrix.shape[1]
+
+    if starting_state_index is None:
+        current_state = np.random.randint(number_of_states)
+    else:
+        current_state = starting_state_index
+
+    time_steps_per_state = np.array([0 for _ in range(number_of_states)])
+
+    time_steps_per_state[current_state] += 1
+
+    for _ in range(time_steps - 1):
+
+        current_state = np.random.choice(
+            number_of_states, p=transition_matrix[current_state]
+        )
+
+        time_steps_per_state[current_state] += 1
+
+    return time_steps_per_state / time_steps
+
+
+def run_monte_carlo_simulation(
+    transition_matrix, repetitions=10000, time_steps=1000, starting_state_index=None
+):
+    """
+    Runs a monte carlo simulation for a given Markov Chain. Across a number of
+    repetitions, what is the average amount of time spent in each state. This
+    works for both absorbing and ergodic Markov chains.
+
+    Parameters
+    -----------
+    transition_matrix - numpy.array: a transition matrix for the Markov chain
+    in question.
+
+    repetitions - int: how many times to simulate the public goods game. By
+    default, this is set to 10000 repetitions of a given public goods game.
+
+    time_steps - int: how many turns to play the public goods game for. By
+    default, this is set to 1000.
+
+    starting_state - int: the index of the state to begin in. If None, this will
+    result in a randomly chosen starting state, and is set to None by default.
+
+    returns:
+    ---------
+    numpy.array: the proportion of time spent in each state across"""
+
+    number_of_states = transition_matrix.shape[1]
+
+    state_distribution = np.array([0 for _ in range(number_of_states)])
+
+    for current_sim in range(1, repetitions + 1):
+
+        state_distribution = (
+            (state_distribution * (current_sim - 1))
+            + simulate_markov_chain(
+                transition_matrix=transition_matrix,
+                starting_state_index=starting_state_index,
+                time_steps=time_steps,
+            )
+        ) / current_sim
+
+    return state_distribution

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -2017,3 +2017,133 @@ def test_approximate_steady_state_for_different_initial_dist():
         ),
         steady_state_2,
     )
+
+
+def test_simulate_markov_chain_for_N_eq_2_various_seeds():
+    """
+    Tests that the simulate_markov_chain function returns the expected values
+    for different random seeds in different numbers of time_steps
+
+    with a seed of 1 and 10 time steps we expect to obtain:
+
+        [0.5, 0.1, 0.2, 0.1]
+
+    with a seed of 12 and 20 time steps we expect to obtain:
+
+        [0.85, 0.  , 0.05, 0.1 ]
+
+    taking the average over 20 simulations with a seed of 7 and 20 timesteps
+    each, we expect to obtain:
+
+        [0.89  , 0.0425, 0.04  , 0.0275]"""
+
+    np.random.seed(1)
+
+    transition_matrix = np.array(
+        [
+            [1, 0, 0, 0],
+            [0.5, 0.2, 0.3, 0],
+            [0.25, 0.25, 0.25, 0.25],
+            [0.1, 0.3, 0.3, 0.3],
+        ]
+    )
+
+    expected_state_distribution = np.array([0.5, 0.2, 0.2, 0.1])
+    actual_state_distribution = main.simulate_markov_chain(
+        transition_matrix=transition_matrix, time_steps=10
+    )
+
+    np.testing.assert_array_equal(
+        actual_state_distribution, expected_state_distribution
+    )
+
+    np.random.seed(12)
+
+    expected_state_distribution_2 = np.array([0.85, 0.0, 0.05, 0.1])
+    actual_state_distribution_2 = main.simulate_markov_chain(
+        transition_matrix=transition_matrix, time_steps=20
+    )
+
+    np.testing.assert_array_equal(
+        actual_state_distribution_2, expected_state_distribution_2
+    )
+
+    np.random.seed(7)
+
+    expected_state_distribution_iteration = np.array([0.89, 0.0425, 0.04, 0.0275])
+    actual_state_distribution_iteration = np.array(
+        [
+            main.simulate_markov_chain(
+                transition_matrix=transition_matrix, time_steps=20
+            )
+            for _ in range(20)
+        ]
+    ).mean(axis=0)
+
+    np.testing.assert_array_almost_equal(
+        actual_state_distribution_iteration, expected_state_distribution_iteration
+    )
+
+
+def test_run_monte_carlo_simulation_for_N_eq_2_and_various_seeds():
+    """
+    Tests that the run_monte_carlo_simulation function returns the expected
+    values for various random seeds.
+
+    When we take a seed of 1 we expect the following:
+
+        [0.8425, 0.0625, 0.0675, 0.0275]
+
+    With a seed of 4 we expect the following:
+
+        [0.83, 0.0675, 0.06, 0.0425]
+
+    With a seed of 8 across 20 realisations we expect an average of:
+
+        [0.870125, 0.046125, 0.05025, 0.0335]"""
+
+    np.random.seed(1)
+
+    transition_matrix = np.array(
+        [
+            [1, 0, 0, 0],
+            [0.5, 0.2, 0.3, 0],
+            [0.25, 0.25, 0.25, 0.25],
+            [0.1, 0.3, 0.3, 0.3],
+        ]
+    )
+
+    expected_distribution_1 = np.array([0.8425, 0.0625, 0.0675, 0.0275])
+
+    actual_distribution_1 = main.run_monte_carlo_simulation(
+        transition_matrix=transition_matrix, time_steps=20, repetitions=20
+    )
+
+    np.testing.assert_array_almost_equal(actual_distribution_1, expected_distribution_1)
+
+    np.random.seed(4)
+
+    expected_distribution_2 = np.array([0.83, 0.0675, 0.06, 0.0425])
+
+    actual_distribution_2 = main.run_monte_carlo_simulation(
+        transition_matrix=transition_matrix, time_steps=20, repetitions=20
+    )
+
+    np.testing.assert_array_almost_equal(actual_distribution_2, expected_distribution_2)
+
+    np.random.seed(8)
+
+    expected_distribution_iteration = np.array([0.870125, 0.046125, 0.05025, 0.0335])
+
+    actual_distribution_iteration = np.array(
+        [
+            main.run_monte_carlo_simulation(
+                transition_matrix=transition_matrix, time_steps=20, repetitions=20
+            )
+            for _ in range(20)
+        ]
+    ).mean(axis=0)
+
+    np.testing.assert_array_almost_equal(
+        actual_distribution_iteration, expected_distribution_iteration
+    )

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -2085,6 +2085,33 @@ def test_simulate_markov_chain_for_N_eq_2_various_seeds():
     )
 
 
+def test_simulate_markov_chain_for_specific_starting_state():
+    """
+    Tests that the simulate_markov_chain function correctly begins in a
+    starting state passed to it."""
+
+    transition_matrix = np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+    starting_state_index = 1
+
+    expected_state_distribution = np.array([0, 1, 0, 0])
+
+    actual_state_distribution = main.simulate_markov_chain(
+        transition_matrix=transition_matrix, starting_state_index=starting_state_index
+    )
+
+    np.testing.assert_array_equal(
+        actual_state_distribution, expected_state_distribution
+    )
+
+
 def test_run_monte_carlo_simulation_for_N_eq_2_and_various_seeds():
     """
     Tests that the run_monte_carlo_simulation function returns the expected


### PR DESCRIPTION
Includes the following functions and associated
tests:

"simulate_markov_chain":
Over a given number of time steps, returns the
proportion of time spent in each state for a
markov chain

"run_monte_carlo_sim":
simulate the markov chain a certain number of
times, getting the average amount of time steps spent in each state across the simulations

The idea is that these functions can be used to
simulate a given (huge) PGG over a massive number of time steps, and to have the ability to run this
a large number of times and take an average in the case of an absorbing Markov chain, so that we can
approximate the absorption probabilities for a
large chain. For a chain which simply approaches a steady state, the functionality of
"simulate_markov_chain" will prove sufficient